### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete multi-character sanitization

### DIFF
--- a/app/assets/javascripts/template-js/jquery.dataTables.js
+++ b/app/assets/javascripts/template-js/jquery.dataTables.js
@@ -24,6 +24,7 @@
 /*jslint evil: true, undef: true, browser: true */
 /*globals $,require,jQuery,define,_selector_run,_selector_opts,_selector_first,_selector_row_indexes,_ext,_Api,_api_register,_api_registerPlural,_re_new_lines,_re_html,_re_formatted_numeric,_re_escape_regex,_empty,_intVal,_numToDecimal,_isNumber,_isHtml,_htmlNumeric,_pluck,_pluck_order,_range,_stripHtml,_unique,_fnBuildAjax,_fnAjaxUpdate,_fnAjaxParameters,_fnAjaxUpdateDraw,_fnAjaxDataSrc,_fnAddColumn,_fnColumnOptions,_fnAdjustColumnSizing,_fnVisibleToColumnIndex,_fnColumnIndexToVisible,_fnVisbleColumns,_fnGetColumns,_fnColumnTypes,_fnApplyColumnDefs,_fnHungarianMap,_fnCamelToHungarian,_fnLanguageCompat,_fnBrowserDetect,_fnAddData,_fnAddTr,_fnNodeToDataIndex,_fnNodeToColumnIndex,_fnGetCellData,_fnSetCellData,_fnSplitObjNotation,_fnGetObjectDataFn,_fnSetObjectDataFn,_fnGetDataMaster,_fnClearTable,_fnDeleteIndex,_fnInvalidate,_fnGetRowElements,_fnCreateTr,_fnBuildHead,_fnDrawHead,_fnDraw,_fnReDraw,_fnAddOptionsHtml,_fnDetectHeader,_fnGetUniqueThs,_fnFeatureHtmlFilter,_fnFilterComplete,_fnFilterCustom,_fnFilterColumn,_fnFilter,_fnFilterCreateSearch,_fnEscapeRegex,_fnFilterData,_fnFeatureHtmlInfo,_fnUpdateInfo,_fnInfoMacros,_fnInitialise,_fnInitComplete,_fnLengthChange,_fnFeatureHtmlLength,_fnFeatureHtmlPaginate,_fnPageChange,_fnFeatureHtmlProcessing,_fnProcessingDisplay,_fnFeatureHtmlTable,_fnScrollDraw,_fnApplyToChildren,_fnCalculateColumnWidths,_fnThrottle,_fnConvertToWidth,_fnGetWidestNode,_fnGetMaxLenString,_fnStringToCss,_fnSortFlatten,_fnSort,_fnSortAria,_fnSortListener,_fnSortAttachListener,_fnSortingClasses,_fnSortData,_fnSaveState,_fnLoadState,_fnSettingsFromNode,_fnLog,_fnMap,_fnBindAction,_fnCallbackReg,_fnCallbackFire,_fnLengthOverflow,_fnRenderer,_fnDataSource,_fnRowAttributes*/
 
+const sanitizeHtml = require('sanitize-html');
 (function( factory ) { 
 	"use strict";
 
@@ -14739,7 +14740,7 @@
 			return _empty(a) ?
 				'' :
 				a.replace ?
-					a.replace( /<.*?>/g, "" ).toLowerCase() :
+					sanitizeHtml(a, { allowedTags: [], allowedAttributes: {} }).toLowerCase() :
 					a+'';
 		},
 	

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "Inventory_Tracker",
   "private": true,
-  "dependencies": {}
+  "dependencies": {
+    "sanitize-html": "^2.14.0"
+  }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/tanuppal/educreon/security/code-scanning/12](https://github.com/tanuppal/educreon/security/code-scanning/12)

To fix the problem, we should replace the current regular expression with a more robust solution that ensures all HTML tags are removed effectively. One way to achieve this is by using a well-tested library like `sanitize-html` to handle the sanitization process. This library is designed to handle various edge cases and provides a more secure way to sanitize HTML content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
