### PR TITLE
Potential fix for code scanning alert no. 7: Useless regular-expression character escape

### DIFF
--- a/app/assets/javascripts/template-js/Chart.bundle.js
+++ b/app/assets/javascripts/template-js/Chart.bundle.js
@@ -3145,8 +3145,8 @@ function localeWeekdaysParse (weekdayName, format, strict) {
         mom = createUTC([2000, 1]).day(i);
         if (strict && !this._fullWeekdaysParse[i]) {
             this._fullWeekdaysParse[i] = new RegExp('^' + this.weekdays(mom, '').replace('.', '\.?') + '$', 'i');
-            this._shortWeekdaysParse[i] = new RegExp('^' + this.weekdaysShort(mom, '').replace('.', '\.?') + '$', 'i');
-            this._minWeekdaysParse[i] = new RegExp('^' + this.weekdaysMin(mom, '').replace('.', '\.?') + '$', 'i');
+            this._shortWeekdaysParse[i] = new RegExp('^' + this.weekdaysShort(mom, '').replace('.', '.?') + '$', 'i');
+            this._minWeekdaysParse[i] = new RegExp('^' + this.weekdaysMin(mom, '').replace('.', '.?') + '$', 'i');
         }
         if (!this._weekdaysParse[i]) {
             regex = '^' + this.weekdays(mom, '') + '|^' + this.weekdaysShort(mom, '') + '|^' + this.weekdaysMin(mom, '');


### PR DESCRIPTION
Potential fix for [https://github.com/tanuppal/educreon/security/code-scanning/7](https://github.com/tanuppal/educreon/security/code-scanning/7)

To fix the problem, we need to remove the unnecessary backslash from the escape sequence `\.` in the regular expression. This will make the regular expression clearer and avoid any confusion about the intended functionality.

- Locate the regular expression on line 3149 in the file `app/assets/javascripts/template-js/Chart.bundle.js`.
- Remove the backslash from the escape sequence `\.` to make it just `.`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
