### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete multi-character sanitization

### DIFF
--- a/app/assets/javascripts/template-js/jquery.dataTables.js
+++ b/app/assets/javascripts/template-js/jquery.dataTables.js
@@ -14646,9 +14646,7 @@ const sanitizeHtml = require('sanitize-html');
 			return _empty(data) ?
 				data :
 				typeof data === 'string' ?
-					data
-						.replace( _re_new_lines, " " )
-						.replace( _re_html, "" ) :
+					sanitizeHtml(data.replace( _re_new_lines, " ")) :
 					'';
 		},
 	


### PR DESCRIPTION
Potential fix for [https://github.com/tanuppal/educreon/security/code-scanning/11](https://github.com/tanuppal/educreon/security/code-scanning/11)

To fix the problem, we should ensure that all instances of the targeted HTML tags are removed from the input string. The best way to achieve this is to use a well-tested sanitization library, such as `sanitize-html`, which is already imported in the code. This library is designed to handle various edge cases and provides a more robust solution for sanitizing HTML content.

We will replace the existing sanitization logic in the `html` function of the `DataTable.ext.type.search` extension with a call to the `sanitizeHtml` library. This change will ensure that all potentially unsafe HTML content is effectively removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
