### PR TITLE
Potential fix for code scanning alert no. 5: Useless regular-expression character escape

### DIFF
--- a/app/assets/javascripts/template-js/Chart.bundle.js
+++ b/app/assets/javascripts/template-js/Chart.bundle.js
@@ -3144,9 +3144,9 @@ function localeWeekdaysParse (weekdayName, format, strict) {
 
         mom = createUTC([2000, 1]).day(i);
         if (strict && !this._fullWeekdaysParse[i]) {
-            this._fullWeekdaysParse[i] = new RegExp('^' + this.weekdays(mom, '').replace('.', '\.?') + '$', 'i');
-            this._shortWeekdaysParse[i] = new RegExp('^' + this.weekdaysShort(mom, '').replace('.', '.?') + '$', 'i');
-            this._minWeekdaysParse[i] = new RegExp('^' + this.weekdaysMin(mom, '').replace('.', '.?') + '$', 'i');
+            this._fullWeekdaysParse[i] = new RegExp('^' + this.weekdays(mom, '').replace('.', '\\.?') + '$', 'i');
+            this._shortWeekdaysParse[i] = new RegExp('^' + this.weekdaysShort(mom, '').replace('.', '\\.?') + '$', 'i');
+            this._minWeekdaysParse[i] = new RegExp('^' + this.weekdaysMin(mom, '').replace('.', '\\.?') + '$', 'i');
         }
         if (!this._weekdaysParse[i]) {
             regex = '^' + this.weekdays(mom, '') + '|^' + this.weekdaysShort(mom, '') + '|^' + this.weekdaysMin(mom, '');


### PR DESCRIPTION
Potential fix for [https://github.com/tanuppal/educreon/security/code-scanning/5](https://github.com/tanuppal/educreon/security/code-scanning/5)

To fix the problem, we need to ensure that the regular expression correctly matches a literal dot character. In a string literal, we need to use double backslashes `\\.` to represent a single backslash in the resulting regular expression. This way, the regular expression will correctly interpret `\\.` as a literal dot.

- Change the escape sequence `\.` to `\\.` in the `replace` method calls on lines 3147, 3148, and 3149.
- This change ensures that the regular expression matches a literal dot character as intended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
